### PR TITLE
QOL: update default OpenAPI version to 3.1.0 #173

### DIFF
--- a/packages/arkos/src/modules/swagger/utils/helpers/get-swagger-default-configs.ts
+++ b/packages/arkos/src/modules/swagger/utils/helpers/get-swagger-default-configs.ts
@@ -17,7 +17,7 @@ export default function getSwaggerDefaultConfig(
     strict: false,
     options: {
       definition: {
-        openapi: "3.0.0",
+        openapi: "3.1.0",
         info: {
           title: "Powered By Arkos.js",
           version: "1.0.0",


### PR DESCRIPTION
Updated the default OpenAPI version to 3.1.0 in swagger configs to improve compatibility with external tools like Orval and ensure modern API documentation standards.