### PR TITLE
fix(cli): use relative entry point path to fix spawn on paths with spaces

### DIFF
--- a/packages/arkos/src/utils/cli/dev.ts
+++ b/packages/arkos/src/utils/cli/dev.ts
@@ -37,6 +37,8 @@ export async function devCommand(options: DevOptions = {}) {
       return process.exit(1);
     }
 
+    const entryPointRelative = path.relative(process.cwd(), entryPoint);
+
     const baseServiceTypesPath = path.resolve(
       process.cwd(),
       `node_modules/@arkosjs/generated/cjs/index.js`
@@ -102,7 +104,7 @@ export async function devCommand(options: DevOptions = {}) {
       const env = getEnv();
 
       if (fileExt === "ts") {
-        child = spawn("npx", ["tsx-strict", "--watch", entryPoint], {
+        child = spawn("npx", ["tsx-strict", "--watch", entryPointRelative], {
           stdio: "inherit",
           env,
           shell: true,
@@ -111,7 +113,7 @@ export async function devCommand(options: DevOptions = {}) {
         env.TSX_TSCONFIG_PATH = "./jsconfig.json";
         child = spawn(
           "npx",
-          ["tsx-strict", "--no-type-check", "--watch", entryPoint],
+          ["tsx-strict", "--no-type-check", "--watch", entryPointRelative],
           {
             stdio: "inherit",
             env,

--- a/packages/arkos/src/utils/cli/export-auth-action.ts
+++ b/packages/arkos/src/utils/cli/export-auth-action.ts
@@ -27,6 +27,8 @@ export default async function exportAuthActionCommand(options: {
       process.exit(1);
     }
 
+    const entryPointRelative = path.relative(process.cwd(), entryPoint);
+
     const getEnv = () =>
       ({
         NODE_ENV: "development",
@@ -42,7 +44,7 @@ export default async function exportAuthActionCommand(options: {
 
       const env = getEnv();
 
-      child = spawn("npx", ["tsx-strict", "--no-type-check", entryPoint], {
+      child = spawn("npx", ["tsx-strict", "--no-type-check", entryPointRelative], {
         stdio: "inherit",
         env,
         shell: true,


### PR DESCRIPTION
### Problem

Running `pnpm dev` in a project located inside a directory with spaces in its path causes the following error:

error: too many arguments. Expected 1 argument but got 2.

### Cause

When the project directory contains spaces, passing an absolute path to `tsx-strict` via `spawn()` with `shell: true` causes the shell to tokenize the path into multiple arguments.

### Solution

Instead of passing an absolute path, we now use:

`path.relative(process.cwd(), entryPoint)`

This ensures the argument passed to `tsx-strict` does not include the project path with spaces, avoiding incorrect tokenization by the shell.

### Result

`pnpm dev` now works correctly even when the project path contains spaces.

Fixes #243