### PR TITLE
docs(readme): fix ArkosRouter typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ postRouter.post(
 export default postRouter;
 ```
 
-See more about the enhaced express-based router (ArkosRouter) at [ArkosRouter Guide](https://www.arkosjs.com/docs/core-concepts/components/routers).
+See more about the enhanced express-based router (ArkosRouter) at [ArkosRouter Guide](https://www.arkosjs.com/docs/core-concepts/components/routers).
 
 ## Define Permissions Once, Guard Everywhere
 

--- a/packages/arkos/README.md
+++ b/packages/arkos/README.md
@@ -77,7 +77,7 @@ postRouter.post(
 export default postRouter;
 ```
 
-See more about the enhaced express-based router (ArkosRouter) at [ArkosRouter Guide](https://www.arkosjs.com/docs/core-concepts/components/routers).
+See more about the enhanced express-based router (ArkosRouter) at [ArkosRouter Guide](https://www.arkosjs.com/docs/core-concepts/components/routers).
 
 ## Define Permissions Once, Guard Everywhere
 


### PR DESCRIPTION
## Summary

Fixes a typo in the ArkosRouter README description.

## Testing

Docs-only change; no tests run.
