### PR TITLE
release(1.5.14-beta)

### DIFF
--- a/packages/arkos/src/modules/auth/auth.service.ts
+++ b/packages/arkos/src/modules/auth/auth.service.ts
@@ -391,7 +391,7 @@ export class AuthService {
     )
       accessControl = getModuleComponents(resource)?.authConfigs?.accessControl;
 
-    authActionService.add(action, resource, accessControl);
+    const authAction = authActionService.add(action, resource, accessControl);
 
     return catchAsync(
       async (req: ArkosRequest, _: ArkosResponse, next: ArkosNextFunction) => {
@@ -405,9 +405,8 @@ export class AuthService {
           }
 
           const notEnoughPermissionsError = new AppError(
-            "You do not have permission to perfom this action",
+            authAction.errorMessage,
             403,
-            {},
             "NotEnoughPermissions"
           );
 

--- a/packages/arkos/src/modules/auth/utils/services/auth-action.service.ts
+++ b/packages/arkos/src/modules/auth/utils/services/auth-action.service.ts
@@ -1,4 +1,4 @@
-import { kebabCase } from "../../../../exports/utils";
+import { kebabCase, sentenceCase } from "../../../../exports/utils";
 import {
   AccessControlConfig,
   DetailedAccessControlRule,
@@ -23,11 +23,15 @@ class AuthActionService {
       resource: "auth-action",
       name: "View auth action",
       description: "View an auth action",
-      errorMessage: "You do not have permission to perform this operation",
+      errorMessage: "You cannot perform view for auth action",
     },
   ];
 
-  add(action: string, resource: string, accessControl?: AccessControlConfig) {
+  add(
+    action: string,
+    resource: string,
+    accessControl?: AccessControlConfig
+  ): Required<AuthAction> {
     const transformedAction = this.transformAccessControlToValidAuthAction(
       action,
       resource,
@@ -40,8 +44,7 @@ class AuthActionService {
 
       const defaultName = `${capitalize(kebabCase(action).replace(/-/g, " "))} ${capitalize(kebabCase(resource).replace(/-/g, " "))}`;
       const defaultDescription = `${capitalize(kebabCase(action).replace(/-/g, " "))} ${capitalize(kebabCase(resource).replace(/-/g, " "))}`;
-      const defaultErrorMessage =
-        "You do not have permission to perform this operation";
+      const defaultErrorMessage = `You cannot perform ${sentenceCase(action).toLowerCase()} for ${sentenceCase(resource).toLowerCase()}`;
 
       const isNonDefault = (
         value: string | undefined,
@@ -100,7 +103,7 @@ class AuthActionService {
         ? [...new Set(mergedRoles)].sort()
         : undefined;
 
-      const merged: AuthAction = {
+      const merged: Required<AuthAction> = {
         action: existingAuthAction.action,
         resource: existingAuthAction.resource,
         roles: uniqueRoles,
@@ -109,15 +112,17 @@ class AuthActionService {
           existingAuthAction.description ?? transformedAction.description,
         errorMessage:
           existingAuthAction.errorMessage ?? transformedAction.errorMessage,
-      };
+      } as any;
 
       this.remove(action, resource);
       this.authActions.push(merged);
+      return merged;
     } else {
       if (transformedAction.roles) {
         transformedAction.roles = [...transformedAction.roles].sort();
       }
       this.authActions.push(transformedAction);
+      return transformedAction;
     }
   }
 
@@ -143,8 +148,8 @@ class AuthActionService {
     action: string,
     resource: string,
     accessControl?: AccessControlConfig
-  ): AuthAction {
-    const baseAuthAction: AuthAction = {
+  ): Required<AuthAction> {
+    const baseAuthAction: Required<AuthAction> = {
       roles:
         (accessControl &&
           (Array.isArray(accessControl)
@@ -165,7 +170,8 @@ class AuthActionService {
 
     const config = getArkosConfig();
 
-    if (config?.authentication?.mode === "dynamic") delete baseAuthAction.roles;
+    if (config?.authentication?.mode === "dynamic")
+      delete (baseAuthAction as any).roles;
 
     if (!accessControl) return baseAuthAction;
 

--- a/packages/arkos/src/modules/swagger/swagger.router.ts
+++ b/packages/arkos/src/modules/swagger/swagger.router.ts
@@ -7,6 +7,7 @@ import express from "express";
 import { ArkosConfig, ArkosRequest, ArkosResponse } from "../../exports";
 import deepmerge from "../../utils/helpers/deepmerge.helper";
 import { OpenAPIV3 } from "openapi-types";
+import { isProduction } from "../../utils/helpers/arkos-config.helpers";
 
 const swaggerRouter = Router();
 
@@ -25,7 +26,11 @@ export async function getSwaggerRouter(
     arkosConfig.swagger || {}
   ) as ArkosConfig["swagger"];
 
-  if (arkosConfig.swagger?.options?.definition?.servers && swaggerConfigs) {
+  if (
+    arkosConfig.swagger?.options?.definition?.servers &&
+    swaggerConfigs &&
+    !isProduction()
+  ) {
     swaggerConfigs!.options!.definition!.servers =
       arkosConfig.swagger.options.definition.servers;
 

--- a/packages/arkos/src/utils/cli/__tests__/build.test.ts
+++ b/packages/arkos/src/utils/cli/__tests__/build.test.ts
@@ -4,6 +4,7 @@ import { buildCommand } from "../build";
 import { getUserFileExtension } from "../../helpers/fs.helpers";
 import { loadEnvironmentVariables } from "../../dotenv.helpers";
 import sheu from "../../sheu";
+import * as startCli from "../start";
 
 // Mock dependencies
 jest.mock("child_process", () => ({
@@ -57,6 +58,12 @@ describe("buildCommand", () => {
     warn: console.warn,
   };
 
+  const mockChildKill = jest.fn();
+  const mockStartCommand = jest
+    .spyOn(startCli, "startCommand")
+    .mockImplementation(() => {
+      return { kill: mockChildKill } as any;
+    });
   // Mock process.exit
   const mockExit = jest.spyOn(process, "exit").mockImplementation((code) => {
     console.error(`Process.exit called with code ${code}`);
@@ -70,6 +77,7 @@ describe("buildCommand", () => {
     console.info = jest.fn();
     console.error = jest.fn();
     console.warn = jest.fn();
+    console.log = jest.fn();
 
     // Mock process.cwd()
     jest.spyOn(process, "cwd").mockReturnValue("/mock/project");
@@ -377,7 +385,7 @@ describe("buildCommand", () => {
     //   expect(packageJsonCalls[0][1]).not.toContain('"type":"module"');
     // });
 
-    it("should handle package.json errors gracefully", () => {
+    it("should handle package.json errors gracefully", async () => {
       (fs.readFileSync as jest.Mock).mockImplementation((path) => {
         if (
           path.includes("package.json") &&
@@ -393,7 +401,7 @@ describe("buildCommand", () => {
         Object.assign("file.txt", { isDirectory: () => {} }),
       ]);
 
-      buildCommand({});
+      await buildCommand({});
 
       // Should still complete without creating a package.json in build dir
       expect(console.info).toHaveBeenCalledWith(
@@ -405,7 +413,7 @@ describe("buildCommand", () => {
   describe("Error handling", () => {
     it("should handle build failures and exit with code 1", () => {
       (getUserFileExtension as jest.Mock).mockReturnValue("ts");
-      (execSync as jest.Mock).mockImplementation(() => {
+      (execFileSync as jest.Mock).mockImplementation(() => {
         throw new Error("Build failed");
       });
 
@@ -421,8 +429,30 @@ describe("buildCommand", () => {
       expect(console.error).toHaveBeenCalledWith(expect.any(Error));
     });
 
-    it("should handle file copy errors gracefully", () => {
-      (execSync as jest.Mock).mockImplementation(() => {
+    it("should handle build failures and exit with code 1 when startCommand fails", async () => {
+      (getUserFileExtension as jest.Mock).mockReturnValue("ts");
+      (execFileSync as jest.Mock).mockImplementation(() => {
+        return true;
+      });
+      const jwtError = new Error("Missing JWT_SECRET in production");
+      mockStartCommand.mockImplementationOnce(() => {
+        throw jwtError;
+      });
+
+      await buildCommand({});
+
+      expect(console.error).toHaveBeenCalledWith(
+        "Process.exit called with code 1"
+      );
+
+      expect(sheu.error).toHaveBeenCalledWith(
+        expect.stringContaining("Build failed:")
+      );
+      expect(console.error).toHaveBeenCalledWith(jwtError);
+    });
+
+    it("should handle file copy errors gracefully", async () => {
+      (execFileSync as jest.Mock).mockImplementation(() => {
         return "";
       });
       (getUserFileExtension as jest.Mock).mockReturnValue("js");
@@ -433,7 +463,7 @@ describe("buildCommand", () => {
         Object.assign("file.txt", { isDirectory: () => {} }),
       ]);
 
-      buildCommand({});
+      await buildCommand({});
 
       expect(console.warn).toHaveBeenCalledWith(
         "Warning: Error copying project files:",

--- a/packages/arkos/src/utils/cli/build.ts
+++ b/packages/arkos/src/utils/cli/build.ts
@@ -25,8 +25,7 @@ interface BuildOptions {
  */
 export async function buildCommand(options: BuildOptions = {}) {
   const fileExt = getUserFileExtension();
-  if (process.env.NODE_ENV === "test" || !process.env.NODE_ENV)
-    process.env.NODE_ENV = "production";
+  if (!process.env.NODE_ENV) process.env.NODE_ENV = "production";
   process.env.ARKOS_BUILD = "true";
 
   const envFiles = loadEnvironmentVariables();

--- a/packages/arkos/src/utils/cli/build.ts
+++ b/packages/arkos/src/utils/cli/build.ts
@@ -8,6 +8,8 @@ import sheu from "../sheu";
 import watermarkStamper from "./utils/watermark-stamper";
 import { removeDir } from "../remove-dir";
 import { bundler } from "../bundler";
+import portAndHostAllocator from "../features/port-and-host-allocator";
+import { startCommand } from "./start";
 
 const BUILD_DIR = ".build";
 const MODULE_TYPES = ["cjs", "esm"] as const;
@@ -21,7 +23,7 @@ interface BuildOptions {
 /**
  * Main build function for the arkos CLI
  */
-export function buildCommand(options: BuildOptions = {}) {
+export async function buildCommand(options: BuildOptions = {}) {
   const fileExt = getUserFileExtension();
   if (process.env.NODE_ENV === "test" || !process.env.NODE_ENV)
     process.env.NODE_ENV = "production";
@@ -43,6 +45,17 @@ export function buildCommand(options: BuildOptions = {}) {
     else buildJavaScriptProject(options, moduleType);
 
     const packageManger = detectPackageManagerFromUserAgent();
+
+    const hostAndPort = await portAndHostAllocator.getHostAndAvailablePort(
+      process.env
+    );
+
+    const child = startCommand({
+      ...hostAndPort,
+      stamp: false,
+      shouldThrow: true,
+    });
+    child.kill();
 
     console.info(`\n\x1b[1m\x1b[32m  Build complete!\x1b[0m\n`);
     console.info(`  \x1b[1mNext step:\x1b[0m`);

--- a/packages/arkos/src/utils/cli/start.ts
+++ b/packages/arkos/src/utils/cli/start.ts
@@ -10,6 +10,7 @@ interface StartOptions {
   port?: string;
   host?: string;
   stamp?: false;
+  shouldThrow?: true;
 }
 
 let child: ChildProcess | null = null;
@@ -72,7 +73,10 @@ export function startCommand(options: StartOptions = {}) {
 
       process.exit(0);
     });
+
+    return child;
   } catch (error) {
+    if (options.shouldThrow) throw error;
     sheu.error("Production server failed to start:");
     console.error(error);
     process.exit(1);


### PR DESCRIPTION
### Changes

- **refactor(#271):** Custom OpenAPI servers in Swagger config are now only applied outside production (`isProduction()` check added in `swagger.router.ts`)
- **feat(#269):** `buildCommand` now attempts to start the server post-build (via `startCommand` with `shouldThrow: true`) to validate the build actually boots before reporting success; build fails with exit code 1 if startup throws
- **feat(#265):** `AuthActionService.add` now returns the resolved `AuthAction` (`Required<AuthAction>`); custom `errorMessage` is now respected, with an improved default error message format (`You cannot perform {action} for {resource}`) using new `sentenceCase` helper
- **fix:** `AuthService` now uses the per-action `errorMessage` from `authActionService.add()` instead of a hardcoded permission error string
- **chore:** Added/updated tests in `build.test.ts` for async `buildCommand`, including a new case covering build failure when `startCommand` throws (e.g. missing `JWT_SECRET` in production)
- **refactor:** Prevented `NODE_ENV` from being overwritten when already set to `test` during build